### PR TITLE
Add id_map dependency

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,3 +4,4 @@ kbapi_common
 auth
 idserver
 workspace_deluxe
+id_map


### PR DESCRIPTION
expression depends on id_map but it doesn't have it in the DEPENDENCIES file.
